### PR TITLE
Increase the limit of file transfer to 16M

### DIFF
--- a/src/webinspector.c
+++ b/src/webinspector.c
@@ -40,7 +40,7 @@
 #define MAX_RPC_LEN 8096 - 500
 
 // some arbitrarly limit, to catch bad packets
-#define MAX_BODY_LENGTH 1<<20
+#define MAX_BODY_LENGTH 1<<24
 
 struct wi_private {
   bool is_sim;


### PR DESCRIPTION
The current file size limitation of 2^20 bytes is too small for some files, we'd like to increase the size to 2^24.
